### PR TITLE
增加sink并行度、超时时间、心跳间隔等参数配置，解决了sink并行度大于1时，sink侧多个client id重复造成的异常

### DIFF
--- a/src/main/java/com/example/flink/connector/mqtt/stream/MqttSinkPaho.java
+++ b/src/main/java/com/example/flink/connector/mqtt/stream/MqttSinkPaho.java
@@ -28,9 +28,13 @@ public class MqttSinkPaho<T> extends RichSinkFunction<T> {
 
     @Override
     public void invoke(T event, Context context) throws Exception {
-        log.info("MqttSink invoke...");
+        if (log.isDebugEnabled()) {
+            log.debug("MqttSink invoke...");
+        }
         byte[] payload = event.toString().getBytes();
-        log.info("messge is {}", event);
+        if (log.isDebugEnabled()) {
+            log.debug("messge is {}", event);
+        }
         int qos = 0;
         // 创建消息并设置 QoS
         MqttMessage message = new MqttMessage(payload);
@@ -40,7 +44,8 @@ public class MqttSinkPaho<T> extends RichSinkFunction<T> {
 
     @Override
     public void close() throws Exception {
-        log.info("MqttSink close...");
+        log.info("sink close...");
+
         super.close();
         // 关闭连接
         client.disconnect();
@@ -50,7 +55,8 @@ public class MqttSinkPaho<T> extends RichSinkFunction<T> {
 
     @Override
     public void open(Configuration parameters) throws Exception {
-        log.info("MqttSink open...");
+        log.info("sink open...");
+
         super.open(parameters);
         String clientId = "FlinkTest_" + Thread.currentThread().getId() % 10000 + "_" + System.currentTimeMillis() % 100000;
         client = new MqttClient(broker, clientId, new MemoryPersistence());

--- a/src/main/java/com/example/flink/connector/mqtt/stream/MqttSourcePaho.java
+++ b/src/main/java/com/example/flink/connector/mqtt/stream/MqttSourcePaho.java
@@ -27,7 +27,8 @@ public class MqttSourcePaho extends RichSourceFunction<MyMqttMessage> implements
     }
 
     private void connect() throws MqttException {
-        log.info("MqttSourcePaho connect");
+        log.info("source connect...");
+
         MqttConnectOptions connOpts = new MqttConnectOptions();
         connOpts.setUserName(this.userName);
         connOpts.setPassword(this.password.toCharArray());
@@ -59,9 +60,11 @@ public class MqttSourcePaho extends RichSourceFunction<MyMqttMessage> implements
 
             @Override
             public void messageArrived(String topic, MqttMessage mqttMessage) {
-                log.info("接收消息主题:" + topic);
-                log.info("接收消息Qos:" + mqttMessage.getQos());
-                log.info("接收消息内容:" + new String(mqttMessage.getPayload()));
+                if (log.isDebugEnabled()) {
+                    log.debug("接收消息主题:" + topic);
+                    log.debug("接收消息Qos:" + mqttMessage.getQos());
+                    log.debug("接收消息内容:\n" + new String(mqttMessage.getPayload()));
+                }
                 String payload = new String(mqttMessage.getPayload());
                 MyMqttMessage message = new MyMqttMessage(topic, payload);
                 if (payload.equals("stop")) {
@@ -73,7 +76,9 @@ public class MqttSourcePaho extends RichSourceFunction<MyMqttMessage> implements
             @Override
             public void deliveryComplete(IMqttDeliveryToken iMqttDeliveryToken) {
                 // 消息交付完成的回调方法
-                log.info("deliveryComplete---------" + iMqttDeliveryToken.isComplete());
+                if (log.isDebugEnabled()) {
+                    log.debug("deliveryComplete---------" + iMqttDeliveryToken.isComplete());
+                }
             }
         });
 
@@ -88,20 +93,24 @@ public class MqttSourcePaho extends RichSourceFunction<MyMqttMessage> implements
 
     @Override
     public void run(SourceContext<MyMqttMessage> sourceContext) throws MqttException, InterruptedException {
-        log.info("MqttSourcePaho run...");
+        log.info("source run...");
+
         this.ctx = sourceContext;
         this.running = true;
         connect();
         while (running) {
             // 继续运行，直到调用 cancel() 方法
-            log.info("MqttSourcePaho keep running...");
+            if (log.isDebugEnabled()) {
+                log.debug("MqttSourcePaho keep running...");
+            }
             Thread.sleep(10000);
         }
     }
 
     @Override
     public void cancel() {
-        log.info("MqttSourcePaho cancel...");
+        log.info("source cancel...");
+
         running = false;
         // 关闭连接
         try {

--- a/src/main/java/com/example/flink/connector/mqtt/stream/MqttWordCount2MqttPaho.java
+++ b/src/main/java/com/example/flink/connector/mqtt/stream/MqttWordCount2MqttPaho.java
@@ -14,12 +14,13 @@ public class MqttWordCount2MqttPaho {
         /**
          * 监听mqtt topicIn的消息，统计每个单词出现的次数后将结果发送给mqtt  topicOut
          */
-        String broker = "tcp://192.168.1.1:1883"; //mqtt的broker地址
-        String username = "abcabc";  //mqtt的账号
-        String password = "123123";  //mqtt的密码
-        String topicIn = "mqtt/wordCount";   //监听的mqtt topic
-        String topicOut = "mqtt/wordCount";  //发送的mqtt topic
+        String broker = "tcp://10.0.113.61:1883"; //mqtt的broker地址
+        String username = "emqxadmin";  //mqtt的账号
+        String password = "JevDDzb!5Qfh5Fmr";  //mqtt的密码
+        String topicIn = "mqtt/source1";   //监听的mqtt topic
+        String topicOut = "mqtt/sink1";  //发送的mqtt topic
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
         // get input data
         DataStream<MyMqttMessage> text = env.addSource(new MqttSourcePaho(broker, username, password, topicIn, 0));
 

--- a/src/main/java/com/example/flink/connector/mqtt/table/FlinkTableJustSource.java
+++ b/src/main/java/com/example/flink/connector/mqtt/table/FlinkTableJustSource.java
@@ -1,23 +1,13 @@
 package com.example.flink.connector.mqtt.table;
 
-import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.api.common.typeinfo.Types;
-import org.apache.flink.api.java.typeutils.RowTypeInfo;
-import org.apache.flink.streaming.api.datastream.DataStream;
-import org.apache.flink.streaming.api.datastream.DataStreamSink;
-import org.apache.flink.streaming.api.functions.ProcessFunction;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
-import org.apache.flink.table.sinks.AppendStreamTableSink;
-import org.apache.flink.table.sinks.TableSink;
-import org.apache.flink.types.Row;
-import org.apache.flink.util.Collector;
-
-import java.util.List;
+import org.apache.flink.table.api.TableResult;
 
 public class FlinkTableJustSource {
 
     public static void main(String[] args) throws Exception {
+
         EnvironmentSettings settings = EnvironmentSettings.newInstance().inStreamingMode().build();
         TableEnvironment tEnv = TableEnvironment.create(settings);
         String sourceSql = "create table flink_mqtt_source(\n" +
@@ -25,17 +15,23 @@ public class FlinkTableJustSource {
                 "  age INTEGER\n" +
                 ") with (\n" +
                 "    'connector' = 'mqtt',\n" +
-                "    'hosturl' = 'tcp://192.168.1.1:1883',\n" +
-                "    'username' = 'abcabc',\n" +
-                "    'password' = '123123',\n" +
-                "    'topic' = 'mqtt/wordCount',\n" +
+                "    'hostUrl' = 'tcp://10.0.113.61:1883',\n" +
+                "    'username' = 'emqxadmin',\n" +
+                "    'password' = 'JevDDzb!5Qfh5Fmr',\n" +
+                "    'sourceTopics' = 'mqtt/source1,mqtt/source2',\n" +
+                "    'clientIdPrefix' = 'source_client1',\n" +
+                "    'cleanSession' = 'true',\n" +
+                "    'autoReconnect' = 'true',\n" +
+                "    'connectionTimeout' = '30',\n" +
+                "    'keepAliveInterval' = '60',\n" +
                 "    'format' = 'json'\n" +
                 ")";
         tEnv.executeSql(sourceSql);
 
         //查询flink_mqtt_source中的数据，下述语句会阻塞住，
-        tEnv.executeSql("SELECT * FROM flink_mqtt_source").print();
-
+        TableResult tableResult = tEnv.executeSql("SELECT * FROM flink_mqtt_source");
+        // 打印输出结果
+        tableResult.print();
         // 启动任务并等待任务完成
         tEnv.execute("Flink MQTT Source Example");
     }

--- a/src/main/java/com/example/flink/connector/mqtt/table/FlinkTableSourceSink.java
+++ b/src/main/java/com/example/flink/connector/mqtt/table/FlinkTableSourceSink.java
@@ -1,6 +1,7 @@
 package com.example.flink.connector.mqtt.table;
 
 import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableEnvironment;
 
 public class FlinkTableSourceSink {
@@ -14,10 +15,15 @@ public class FlinkTableSourceSink {
                 "  age INTEGER\n" +
                 ") with (\n" +
                 "    'connector' = 'mqtt',\n" +
-                "    'hosturl' = 'tcp://192.168.1.1:1883',\n" +
-                "    'username' = 'abcabc',\n" +
-                "    'password' = '123123',\n" +
-                "    'topic' = 'mqtt/wordCount',\n" +
+                "    'hostUrl' = 'tcp://10.0.113.61:1883',\n" +
+                "    'username' = 'emqxadmin',\n" +
+                "    'password' = 'JevDDzb!5Qfh5Fmr',\n" +
+                "    'sourceTopics' = 'mqtt/source1,mqtt/source2',\n" +
+                "    'clientIdPrefix' = 'source_client2',\n" +
+                "    'cleanSession' = 'true',\n" +
+                "    'autoReconnect' = 'true',\n" +
+                "    'connectionTimeout' = '30',\n" +
+                "    'keepAliveInterval' = '60',\n" +
                 "    'format' = 'json'\n" +
                 ")";
         tEnv.executeSql(sourceSql);
@@ -27,25 +33,24 @@ public class FlinkTableSourceSink {
                 "  age INTEGER\n" +
                 ") with (\n" +
                 "    'connector' = 'mqtt',\n" +
-                "    'hosturl' = 'tcp://192.168.1.1:1883',\n" +
-                "    'username' = 'abcabc',\n" +
-                "    'password' = '123123',\n" +
-                "    'topic' = 'mqtt/wordCount',\n" +
+                "    'hostUrl' = 'tcp://10.0.113.61:1883',\n" +
+                "    'username' = 'emqxadmin',\n" +
+                "    'password' = 'JevDDzb!5Qfh5Fmr',\n" +
+                "    'sinkTopics' = 'mqtt/sink1,mqtt/sink2',\n" +
+                "    'qos' = '1',\n" +
+                "    'clientIdPrefix' = 'sink_client2',\n" +
+                "    'autoReconnect' = 'true',\n" +
+                "    'connectionTimeout' = '30',\n" +
+                "    'keepAliveInterval' = '60',\n" +
                 "    'format' = 'json'\n" +
                 ")";
         tEnv.executeSql(sinkSql);
 
-        //将flink_mqtt_source中的结果写入到flink_mqtt_sink表中，这里有个bug，flink根本就没来得及写入数据，就断开了mqtt侧的连接，之后死循环地重连，chatgpt的回复如下
-        // 在使用 Table API 的情况下，executeSql 方法执行 INSERT INTO 语句会立即执行该语句并完成写入操作，然后结束作业。因此，在这个示例中，tEnv.executeSql(insertSql); 执行后，确实会将 flink_mqtt_source 的数据写入到 flink_mqtt_sink 表中，但也导致了 flink_mqtt_source 表监听的断开。
-        // 由于 Flink SQL 是静态的，不适合用于实时的数据流，所以 Table API 在这种场景下使用比较受限。
-        // 如果你希望在持续监听 MQTT 消息并实时写入 flink_mqtt_sink 表中，可以继续使用 DataStream API 的方式。上面之前给出的基于 DataStream API 的示例代码可以满足这个需求，因为 DataStream API 允许你使用异步或连续的方式处理实时数据流，保持 Flink 作业一直运行。
-        // 所以，如果你希望保持持续监听 MQTT 消息并实时写入 flink_mqtt_sink 表中，建议使用 DataStream API 来处理。如果有其他特殊需求，也可以考虑使用 Flink 的 ProcessFunction 或其他更灵活的方式来实现。
+        //将flink_mqtt_source中的结果写入到flink_mqtt_sink表中，该语句会一直从mqtt中读取数据并写入到mqtt
         tEnv.executeSql("INSERT INTO flink_mqtt_sink SELECT username,age FROM flink_mqtt_source");
-        //下面两句跟上面的insert into的效果是一样的
+        //下面两句与上面的insert into效果是一样的
 //        Table sourceTable = tEnv.from("flink_mqtt_source");
 //        sourceTable.executeInsert("flink_mqtt_sink");
-        // 触发作业执行
-        tEnv.execute("Flink Table Job");
     }
 
 

--- a/src/main/java/com/example/flink/connector/mqtt/table/MqttDynamicTableFactory.java
+++ b/src/main/java/com/example/flink/connector/mqtt/table/MqttDynamicTableFactory.java
@@ -3,7 +3,6 @@ package com.example.flink.connector.mqtt.table;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.configuration.ConfigOption;
-import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.format.DecodingFormat;
@@ -15,8 +14,8 @@ import org.apache.flink.table.factories.*;
 
 import java.util.HashSet;
 import java.util.Set;
-import java.util.UUID;
 
+import static com.example.flink.connector.mqtt.table.MqttOptions.*;
 import static org.apache.flink.table.factories.FactoryUtil.createTableFactoryHelper;
 
 public class MqttDynamicTableFactory implements DynamicTableSourceFactory, DynamicTableSinkFactory {
@@ -94,37 +93,5 @@ public class MqttDynamicTableFactory implements DynamicTableSourceFactory, Dynam
         options.add(CLIENTID);
         return options;
     }
-
-    //TODO 5、定义MQTT Connector需要的各项参数
-    public static final ConfigOption<String> HOSTURL =
-            ConfigOptions.key("hosturl")
-                    .stringType()
-                    .noDefaultValue()
-                    .withDescription("the mqtt's connect hosturl.");
-
-    public static final ConfigOption<String> USERNAME =
-            ConfigOptions.key("username")
-                    .stringType()
-                    .noDefaultValue()
-                    .withDescription("the mqtt's connect username.");
-
-    public static final ConfigOption<String> PASSWORD =
-            ConfigOptions.key("password")
-                    .stringType()
-                    .noDefaultValue()
-                    .withDescription("the mqtt's connect password.");
-
-    public static final ConfigOption<String> TOPIC =
-            ConfigOptions.key("topic")
-                    .stringType()
-                    .noDefaultValue()
-                    .withDescription("the mqtt's connect topic.");
-
-    public static final ConfigOption<String> CLIENTID =
-            ConfigOptions.key("clientid")
-                    .stringType()
-                    .defaultValue(String.valueOf(UUID.randomUUID()))
-                    .withDescription("the mqtt's connect clientId.");
-
 
 }

--- a/src/main/java/com/example/flink/connector/mqtt/table/MqttDynamicTableFactory.java
+++ b/src/main/java/com/example/flink/connector/mqtt/table/MqttDynamicTableFactory.java
@@ -22,7 +22,7 @@ public class MqttDynamicTableFactory implements DynamicTableSourceFactory, Dynam
 
     @Override
     /**
-     * TODO　１、创建动态表source
+     * １、创建动态表source和sink
      * DynamicTableFactory需要具备以下功能：
      *      -定义与校验建表时传入的各项参数；
      *      -获取表的元数据；
@@ -69,17 +69,16 @@ public class MqttDynamicTableFactory implements DynamicTableSourceFactory, Dynam
     }
 
     @Override
-    //TODO　２、指定工厂类的标识符，该标识符就是建表时必须填写的connector参数的值
+    //２、指定工厂类的标识符，该标识符就是建表时必须填写的connector参数的值
     public String factoryIdentifier() {
         return "mqtt";
     }
 
     @Override
-    //TODO 3、with里面必须要填写的属性配置
+    //3、with里面必须要填写的属性配置
     public Set<ConfigOption<?>> requiredOptions() {
         final Set<ConfigOption<?>> options = new HashSet<>();
-        options.add(HOSTURL);
-        options.add(TOPIC);
+        options.add(HOST_URL);
         options.add(USERNAME);
         options.add(PASSWORD);
         options.add(FactoryUtil.FORMAT); // use pre-defined option for format
@@ -87,10 +86,17 @@ public class MqttDynamicTableFactory implements DynamicTableSourceFactory, Dynam
     }
 
     @Override
-    //TODO　４、with里面非必须填写属性配置
+    //４、with里面非必须填写属性配置
     public Set<ConfigOption<?>> optionalOptions() {
         final Set<ConfigOption<?>> options = new HashSet<>();
-        options.add(CLIENTID);
+        options.add(CLIENT_ID_PREFIX);
+        options.add(SOURCE_TOPICS);
+        options.add(SINK_TOPICS);
+        options.add(QOS);
+        options.add(AUTOMATIC_RECONNECT);
+        options.add(CLEAN_SESSION);
+        options.add(CONNECTION_TIMEOUT);
+        options.add(KEEP_ALIVE_INTERVAL);
         return options;
     }
 

--- a/src/main/java/com/example/flink/connector/mqtt/table/MqttDynamicTableSink.java
+++ b/src/main/java/com/example/flink/connector/mqtt/table/MqttDynamicTableSink.java
@@ -10,6 +10,8 @@ import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.sink.SinkFunctionProvider;
 import org.apache.flink.table.data.RowData;
 
+import static com.example.flink.connector.mqtt.table.MqttOptions.*;
+
 public class MqttDynamicTableSink implements DynamicTableSink {
     private ReadableConfig options;
     private ResolvedSchema schema;
@@ -31,8 +33,19 @@ public class MqttDynamicTableSink implements DynamicTableSink {
         final SerializationSchema<RowData> serializer = encodingFormat.createRuntimeEncoder(
                 context,
                 schema.toPhysicalRowDataType());
-        final SinkFunction<RowData> sinkFunction = new MqttSinkFunction<>(options, serializer);
-        return SinkFunctionProvider.of(sinkFunction);
+        String hostUrl = this.options.get(HOST_URL);
+        String username = this.options.get(USERNAME);
+        String password = this.options.get(PASSWORD);
+        String topics = this.options.get(SINK_TOPICS);
+        Integer qos = this.options.get(QOS);
+        String clientIdPrefix = this.options.get(CLIENT_ID_PREFIX);
+        Integer connectionTimeout = this.options.get(CONNECTION_TIMEOUT);
+        Integer keepAliveInterval = this.options.get(KEEP_ALIVE_INTERVAL);
+        boolean automaticReconnect = this.options.get(AUTOMATIC_RECONNECT);
+        final SinkFunction<RowData> sinkFunction = new MqttSinkFunction<>(hostUrl, username, password, topics, qos, clientIdPrefix, connectionTimeout, keepAliveInterval, automaticReconnect, serializer);
+
+        Integer sinkParallelism = this.options.get(SINK_PARALLELISM);
+        return SinkFunctionProvider.of(sinkFunction,sinkParallelism);
     }
 
     @Override

--- a/src/main/java/com/example/flink/connector/mqtt/table/MqttDynamicTableSource.java
+++ b/src/main/java/com/example/flink/connector/mqtt/table/MqttDynamicTableSource.java
@@ -12,6 +12,8 @@ import org.apache.flink.table.connector.source.SourceFunctionProvider;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.types.RowKind;
 
+import static com.example.flink.connector.mqtt.table.MqttOptions.*;
+
 public class MqttDynamicTableSource implements ScanTableSource {
     private ReadableConfig options;
     private ResolvedSchema schema;
@@ -42,7 +44,16 @@ public class MqttDynamicTableSource implements ScanTableSource {
         final DeserializationSchema<RowData> deserializer = decodingFormat.createRuntimeDecoder(
                 ctx,
                 schema.toPhysicalRowDataType());
-        final SourceFunction<RowData> sourceFunction = new MqttSourceFunction(options, deserializer);
+        String broker = this.options.get(HOST_URL);
+        String username = this.options.get(USERNAME);
+        String password = this.options.get(PASSWORD);
+        String topics = this.options.get(SOURCE_TOPICS);
+        boolean cleanSession = this.options.get(CLEAN_SESSION);
+        String clientIdPrefix = this.options.get(CLIENT_ID_PREFIX);
+        Integer connectionTimeout = this.options.get(CONNECTION_TIMEOUT);
+        Integer keepAliveInterval = this.options.get(KEEP_ALIVE_INTERVAL);
+        boolean automaticReconnect = this.options.get(AUTOMATIC_RECONNECT);
+        final SourceFunction<RowData> sourceFunction = new MqttSourceFunction<>(broker, username, password, topics, cleanSession, clientIdPrefix, automaticReconnect, connectionTimeout, keepAliveInterval, deserializer);
         return SourceFunctionProvider.of(sourceFunction, false);
     }
 

--- a/src/main/java/com/example/flink/connector/mqtt/table/MqttOptions.java
+++ b/src/main/java/com/example/flink/connector/mqtt/table/MqttOptions.java
@@ -9,12 +9,12 @@ public class MqttOptions {
     private MqttOptions() {
     }
 
-    //TODO 5、定义MQTT Connector需要的各项参数
-    public static final ConfigOption<String> HOSTURL =
-            ConfigOptions.key("hosturl")
+    //5、定义MQTT Connector需要的各项参数
+    public static final ConfigOption<String> HOST_URL =
+            ConfigOptions.key("hostUrl")
                     .stringType()
                     .noDefaultValue()
-                    .withDescription("the mqtt's connect hosturl.");
+                    .withDescription("the mqtt's connect host url.");
 
     public static final ConfigOption<String> USERNAME =
             ConfigOptions.key("username")
@@ -28,16 +28,57 @@ public class MqttOptions {
                     .noDefaultValue()
                     .withDescription("the mqtt's connect password.");
 
-    public static final ConfigOption<String> TOPIC =
-            ConfigOptions.key("topic")
+    public static final ConfigOption<String> SINK_TOPICS =
+            ConfigOptions.key("sinkTopics")
                     .stringType()
                     .noDefaultValue()
-                    .withDescription("the mqtt's connect topic.");
+                    .withDescription("the mqtt's sink topic.");
 
-    public static final ConfigOption<String> CLIENTID =
-            ConfigOptions.key("clientid")
+    public static final ConfigOption<String> SOURCE_TOPICS =
+            ConfigOptions.key("sourceTopics")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("the mqtt's source topics.");
+
+    public static final ConfigOption<String> CLIENT_ID_PREFIX =
+            ConfigOptions.key("clientIdPrefix")
                     .stringType()
                     .defaultValue(String.valueOf(UUID.randomUUID()))
-                    .withDescription("the mqtt's connect clientId.");
+                    .withDescription("the mqtt's connect client id's prefix.");
 
+    public static final ConfigOption<Integer> QOS =
+            ConfigOptions.key("qos")
+                    .intType()
+                    .defaultValue(1)
+                    .withDescription("the mqtt's sink qos.");
+
+    public static final ConfigOption<Boolean> AUTOMATIC_RECONNECT =
+            ConfigOptions.key("autoReconnect")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription("the mqtt's connect automatic reconnect.");
+
+    public static final ConfigOption<Boolean> CLEAN_SESSION =
+            ConfigOptions.key("cleanSession")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription("the mqtt's source clean session.");
+
+    public static final ConfigOption<Integer> CONNECTION_TIMEOUT =
+            ConfigOptions.key("connectionTimeout")
+                    .intType()
+                    .defaultValue(30)
+                    .withDescription("the mqtt's connect timeout.");
+
+    public static final ConfigOption<Integer> KEEP_ALIVE_INTERVAL =
+            ConfigOptions.key("keepAliveInterval")
+                    .intType()
+                    .defaultValue(60)
+                    .withDescription("the mqtt's connect keep alive interval.");
+
+    public static final ConfigOption<Integer> SINK_PARALLELISM =
+            ConfigOptions.key("sinkParallelism")
+                    .intType()
+                    .defaultValue(Runtime.getRuntime().availableProcessors())
+                    .withDescription("the mqtt's sink parallelism.");
 }

--- a/src/main/java/com/example/flink/connector/mqtt/table/MqttOptions.java
+++ b/src/main/java/com/example/flink/connector/mqtt/table/MqttOptions.java
@@ -1,0 +1,43 @@
+package com.example.flink.connector.mqtt.table;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+
+import java.util.UUID;
+
+public class MqttOptions {
+    private MqttOptions() {
+    }
+
+    //TODO 5、定义MQTT Connector需要的各项参数
+    public static final ConfigOption<String> HOSTURL =
+            ConfigOptions.key("hosturl")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("the mqtt's connect hosturl.");
+
+    public static final ConfigOption<String> USERNAME =
+            ConfigOptions.key("username")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("the mqtt's connect username.");
+
+    public static final ConfigOption<String> PASSWORD =
+            ConfigOptions.key("password")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("the mqtt's connect password.");
+
+    public static final ConfigOption<String> TOPIC =
+            ConfigOptions.key("topic")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("the mqtt's connect topic.");
+
+    public static final ConfigOption<String> CLIENTID =
+            ConfigOptions.key("clientid")
+                    .stringType()
+                    .defaultValue(String.valueOf(UUID.randomUUID()))
+                    .withDescription("the mqtt's connect clientId.");
+
+}

--- a/src/main/java/com/example/flink/connector/mqtt/table/MqttSinkFunction.java
+++ b/src/main/java/com/example/flink/connector/mqtt/table/MqttSinkFunction.java
@@ -11,7 +11,7 @@ import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static com.example.flink.connector.mqtt.table.MqttDynamicTableFactory.*;
+import static com.example.flink.connector.mqtt.table.MqttOptions.*;
 
 public class MqttSinkFunction<T> extends RichSinkFunction<T> {
     private static final Logger log = LoggerFactory.getLogger(MqttSinkFunction.class);

--- a/src/main/java/com/example/flink/connector/mqtt/table/MqttSinkFunction.java
+++ b/src/main/java/com/example/flink/connector/mqtt/table/MqttSinkFunction.java
@@ -2,7 +2,6 @@ package com.example.flink.connector.mqtt.table;
 
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
 import org.eclipse.paho.client.mqttv3.MqttClient;
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
@@ -11,7 +10,7 @@ import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static com.example.flink.connector.mqtt.table.MqttOptions.*;
+import java.util.UUID;
 
 public class MqttSinkFunction<T> extends RichSinkFunction<T> {
     private static final Logger log = LoggerFactory.getLogger(MqttSinkFunction.class);
@@ -19,26 +18,45 @@ public class MqttSinkFunction<T> extends RichSinkFunction<T> {
     private static final long serialVersionUID = -6429278620184672870L;
     private transient MqttClient client;
     //MQTT连接配置信息
-    private ReadableConfig conf;
-    private SerializationSchema<T> serializer;
+    private final String topics;
+    private final String hostUrl;
+    private final String username;
+    private final String password;
+    private final Integer qos;
+    private final String clientIdPrefix;
+    private final Integer connectionTimeout;
+    private final Integer keepAliveInterval;
+    private final boolean automaticReconnect;
+    private final SerializationSchema<T> serializer;
 
-    public MqttSinkFunction(ReadableConfig conf, SerializationSchema<T> serializer) {
-        this.conf = conf;
+    public MqttSinkFunction(String hostUrl, String username, String password, String topics, Integer qos, String clientIdPrefix, Integer connectionTimeout, Integer keepAliveInterval, boolean automaticReconnect, SerializationSchema<T> serializer) {
+        this.hostUrl = hostUrl;
+        this.username = username;
+        this.password = password;
+        this.topics = topics;
+        this.qos = qos;
+        this.clientIdPrefix = clientIdPrefix;
+        this.connectionTimeout = connectionTimeout;
+        this.keepAliveInterval = keepAliveInterval;
+        this.automaticReconnect = automaticReconnect;
         this.serializer = serializer;
     }
 
 
     @Override
     public void invoke(T event, Context context) throws Exception {
-        log.info("sink invoke...");
-        log.info("message is {}", event);
+        if (log.isDebugEnabled()) {
+            log.debug("sink invoke...");
+            log.debug("message is {}", event);
+        }
         byte[] payload = this.serializer.serialize(event);
-        int qos = 0;
         // 创建消息并设置 QoS
         MqttMessage message = new MqttMessage(payload);
-        message.setQos(qos);
-
-        this.client.publish(this.conf.get(TOPIC), message);
+        message.setQos(this.qos);
+        String[] topics = this.topics.split(",");
+        for (String topic : topics) {
+            this.client.publish(topic, message);
+        }
     }
 
     @Override
@@ -47,9 +65,9 @@ public class MqttSinkFunction<T> extends RichSinkFunction<T> {
         super.close();
         // 关闭连接
         if (this.client.isConnected()) {
-            client.disconnect();
+            this.client.disconnect();
             // 关闭客户端
-            client.close();
+            this.client.close();
         }
     }
 
@@ -57,12 +75,17 @@ public class MqttSinkFunction<T> extends RichSinkFunction<T> {
     public void open(Configuration parameters) throws Exception {
         log.info("sink open...");
         super.open(parameters);
-        this.client = new MqttClient(this.conf.get(HOSTURL), conf.get(CLIENTID), new MemoryPersistence());
+        String clientId = this.clientIdPrefix + "_" + UUID.randomUUID();
+        this.client = new MqttClient(this.hostUrl, clientId, new MemoryPersistence());
         MqttConnectOptions options = new MqttConnectOptions();
-        options.setUserName(this.conf.get(USERNAME));
-        options.setPassword(this.conf.get(PASSWORD).toCharArray());
+        options.setUserName(this.username);
+        options.setPassword(this.password.toCharArray());
+        // 设置超时时间
+        options.setConnectionTimeout(this.connectionTimeout);
+        // 设置会话心跳时间
+        options.setKeepAliveInterval(this.keepAliveInterval);
         //自动重新连接，默认为false
-        options.setAutomaticReconnect(true);
+        options.setAutomaticReconnect(this.automaticReconnect);
         this.client.connect(options);
     }
 

--- a/src/main/java/com/example/flink/connector/mqtt/table/MqttSourceFunction.java
+++ b/src/main/java/com/example/flink/connector/mqtt/table/MqttSourceFunction.java
@@ -13,7 +13,7 @@ import java.io.IOException;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 
-import static com.example.flink.connector.mqtt.table.MqttDynamicTableFactory.*;
+import static com.example.flink.connector.mqtt.table.MqttOptions.*;
 
 
 public class MqttSourceFunction extends RichSourceFunction<RowData> {


### PR DESCRIPTION
1. 将table api中的mqtt options单独成一个类
2. 增加sink并行度、超时时间、心跳间隔等参数配置
3. 解决了sink并行度大于1时，sink侧多个client id重复造成的异常